### PR TITLE
close client handle after copy

### DIFF
--- a/MobileDevice/iPhone.cs
+++ b/MobileDevice/iPhone.cs
@@ -988,7 +988,9 @@ namespace MK.MobileDevice
             IntPtr lockdownClient;
             IntPtr afcC;
             var afce = AFC.afc_client_start_service(currDevice, out afcC, "MK-iMD");
-            return AFC.copyToDisk(afcC, deviceFile, computerFile) == AFC.AFCError.AFC_E_SUCCESS;
+            var result = AFC.copyToDisk(afcC, deviceFile, computerFile);
+	        var clientCloseResult = AFC.afc_client_free(afcC);
+	        return result == AFC.AFCError.AFC_E_SUCCESS;
         }
 
         public void DeleteDirectory(string path, bool recursive)


### PR DESCRIPTION
I found that copying a large number of files at once would stall out and fail after around 80 or so files were copied. I tracked it down to this method, and with this change I can copy (for example) all the voice memos on my phone (201)